### PR TITLE
Ability to parse files from remote URL

### DIFF
--- a/yaml_test.go
+++ b/yaml_test.go
@@ -20,6 +20,7 @@ var parsetests = []ParseTest{
 	{"testdata/dir", false, []string{"foo", "bar", "baz"}},
 	{"testdata/dir/a.yaml", false, []string{"foo"}},
 	{"testdata/dir/b.yaml", false, []string{"bar", "baz"}},
+	{"https://raw.githubusercontent.com/jcrossley3/manifestival/master/testdata/file.yaml", true, []string{"a", "b"}},
 }
 
 func TestParsing(t *testing.T) {


### PR DESCRIPTION
If a pathname specified in `Parse(pathname string, recursive bool)` is valid URL, we try to parse file on this URL.