### PR TITLE
Refactor parsing logic to use reader primitives.

### DIFF
--- a/filter_test.go
+++ b/filter_test.go
@@ -8,7 +8,11 @@ import (
 )
 
 func TestFilter(t *testing.T) {
-	f := NewYamlManifest("testdata/", true, nil)
+	f, err := NewYamlManifest("testdata/", true, nil)
+	if err != nil {
+		t.Errorf("NewYamlManifest() = %v, wanted no error", err)
+	}
+
 	actual := f.DeepCopyResources()
 	if len(actual) != 5 {
 		t.Errorf("Failed to read all resources: %s", actual)
@@ -36,7 +40,11 @@ func TestFilter(t *testing.T) {
 }
 
 func TestFilterCombo(t *testing.T) {
-	f := NewYamlManifest("testdata/", true, nil)
+	f, err := NewYamlManifest("testdata/", true, nil)
+	if err != nil {
+		t.Errorf("NewYamlManifest() = %v, wanted no error", err)
+	}
+
 	actual := f.DeepCopyResources()
 	if len(actual) != 5 {
 		t.Errorf("Failed to read all resources: %s", actual)

--- a/manifestival.go
+++ b/manifestival.go
@@ -40,9 +40,13 @@ type YamlManifest struct {
 
 var _ Manifest = &YamlManifest{}
 
-func NewYamlManifest(pathname string, recursive bool, client client.Client) Manifest {
+func NewYamlManifest(pathname string, recursive bool, client client.Client) (Manifest, error) {
 	log.Info("Reading YAML file", "name", pathname)
-	return &YamlManifest{resources: Parse(pathname, recursive), client: client}
+	resources, err := Parse(pathname, recursive)
+	if err != nil {
+		return nil, err
+	}
+	return &YamlManifest{resources: resources, client: client}, nil
 }
 
 func (f *YamlManifest) ApplyAll() error {

--- a/manifestival_test.go
+++ b/manifestival_test.go
@@ -1,3 +1,26 @@
 package manifestival_test
 
-// TODO: kubernetes/fake
+import (
+	"testing"
+
+	. "github.com/jcrossley3/manifestival"
+)
+
+func TestFinding(t *testing.T) {
+	f, err := NewYamlManifest("testdata/", true, nil)
+	if err != nil {
+		t.Errorf("NewYamlManifest() = %v, wanted no error", err)
+	}
+
+	f.Filter(ByNamespace("fubar"))
+	actual := f.Find("v1", "A", "foo")
+	if actual == nil {
+		t.Error("Failed to find resource")
+	}
+	if actual.GetNamespace() != "fubar" {
+		t.Errorf("Resource has wrong namespace: %s", actual)
+	}
+	if f.Find("NO", "NO", "NO") != nil {
+		t.Error("Missing resource found")
+	}
+}

--- a/yaml.go
+++ b/yaml.go
@@ -1,133 +1,105 @@
 package manifestival
 
 import (
-	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
-	"path"
+	"path/filepath"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
-func Parse(pathname string, recursive bool) []unstructured.Unstructured {
-	in, out := make(chan []byte, 10), make(chan unstructured.Unstructured, 10)
-	go read(pathname, recursive, in)
-	go decode(in, out)
-	result := []unstructured.Unstructured{}
-	for spec := range out {
-		result = append(result, spec)
-	}
-	return result
-}
-
-func read(pathname string, recursive bool, sink chan []byte) {
-	defer close(sink)
-
+// Parse parses YAML files into Unstructured objects.
+//
+// It supports 4 cases today:
+// 1. pathname = path to a file --> parses that file.
+// 2. pathname = path to a directory, recursive = false --> parses all files in
+//    that directory.
+// 3. pathname = path to a directory, recursive = true --> parses all files in
+//    that directory and it's descendants
+// 4. pathname = url --> fetches the contents of that URL and parses them as YAML.
+func Parse(pathname string, recursive bool) ([]unstructured.Unstructured, error) {
 	if isURL(pathname) {
-		readFileFromURL(pathname, sink)
-	} else {
-		file, err := os.Stat(pathname)
-		if err != nil {
-			log.Error(err, "Unable to get file info")
-			return
-		}
-		if file.IsDir() {
-			readDir(pathname, recursive, sink)
-		} else {
-			readFile(pathname, sink)
-		}
+		return parseURL(pathname)
 	}
+
+	return parseTree(pathname, recursive)
 }
 
-func readDir(pathname string, recursive bool, sink chan []byte) {
-	list, err := ioutil.ReadDir(pathname)
+// parseFile parses a single file.
+func parseFile(pathname string) ([]unstructured.Unstructured, error) {
+	file, err := os.Open(pathname)
 	if err != nil {
-		log.Error(err, "Unable to read directory")
-		return
-	}
-	for _, f := range list {
-		name := path.Join(pathname, f.Name())
-		switch {
-		case f.IsDir() && recursive:
-			readDir(name, recursive, sink)
-		case !f.IsDir():
-			readFile(name, sink)
-		}
-	}
-}
-
-func readFile(filename string, sink chan []byte) {
-	file, err := os.Open(filename)
-	if err != nil {
-		panic(err.Error())
+		return nil, err
 	}
 	defer file.Close()
 
-	buf := buffer(file)
-	readYaml(file, sink, buf)
+	return parse(file)
 }
 
-func readFileFromURL(pathname string, sink chan []byte) {
-	resp, err := http.Get(pathname)
+// parseTree parses a whole tree of files. Descendant directories will be ignored
+// if the recursive flag is set to false.
+func parseTree(root string, recursive bool) ([]unstructured.Unstructured, error) {
+	aggregated := []unstructured.Unstructured{}
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			// Skip directories if no recursive behavior is wanted.
+			if path != root && !recursive {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		els, err := parseFile(path)
+		if err != nil {
+			return err
+		}
+		aggregated = append(aggregated, els...)
+		return nil
+	})
 	if err != nil {
-		log.Error(err, "Unable to read file from remote URL")
-		panic(err.Error())
+		return nil, err
+	}
+	return aggregated, nil
+}
+
+// parseURL fetches a URL and parses its contents as YAML.
+func parseURL(url string) ([]unstructured.Unstructured, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
 	}
 	defer resp.Body.Close()
 
-	buf := bufferResponse(resp)
-	readYaml(resp.Body, sink, buf)
+	return parse(resp.Body)
 }
 
-func readYaml(file io.ReadCloser, sink chan []byte, buf []byte) {
-	manifests := yaml.NewDocumentDecoder(file)
-	defer manifests.Close()
+// parse consumes the given reader and parses its contents as YAML.
+func parse(reader io.Reader) ([]unstructured.Unstructured, error) {
+	decoder := yaml.NewYAMLToJSONDecoder(reader)
+	objs := []unstructured.Unstructured{}
+	var err error
 	for {
-		size, err := manifests.Read(buf)
-		if err == io.EOF {
+		out := unstructured.Unstructured{}
+		err = decoder.Decode(&out)
+		if err != nil {
 			break
 		}
-		b := make([]byte, size)
-		copy(b, buf)
-		sink <- b
+		objs = append(objs, out)
 	}
+	if err != io.EOF {
+		return nil, err
+	}
+	return objs, nil
 }
 
-func decode(in chan []byte, out chan unstructured.Unstructured) {
-	for buf := range in {
-		spec := unstructured.Unstructured{}
-		err := yaml.NewYAMLToJSONDecoder(bytes.NewReader(buf)).Decode(&spec)
-		if err != nil {
-			if err != io.EOF {
-				log.Error(err, "Unable to decode YAML; ignoring")
-			}
-			continue
-		}
-		out <- spec
-	}
-	close(out)
-}
-
-func buffer(file *os.File) []byte {
-	var size int64 = bytes.MinRead
-	if fi, err := file.Stat(); err == nil {
-		size = fi.Size()
-	}
-	return make([]byte, size)
-}
-
-func bufferResponse(resp *http.Response) []byte {
-	var size int64 = bytes.MinRead
-	if resp.ContentLength != -1 {
-		size = resp.ContentLength
-	}
-	return make([]byte, size)
-}
-
+// isURL checks whether or not the given path parses as a URL.
 func isURL(pathname string) bool {
 	_, err := url.ParseRequestURI(pathname)
 	return err == nil


### PR DESCRIPTION
This refactors the YAML parsing logic to use golang's reader primitives. The main reason for that refactoring is to be able to have error handling throughout the reading/parsing code, which bubbles up to the caller automatically.

Also:
- Refactored parsing tests to be in a single table-based test case.
- Generalized all file parsing (single files, directories, recursive directories) under a `parseTree` function.