### PR TITLE
Compare resource specs and only apply if changed

### DIFF
--- a/manifestival.go
+++ b/manifestival.go
@@ -175,6 +175,10 @@ func updateChanged(src, tgt interface{}) bool {
 			}
 		}
 	case []interface{}:
+		// TODO: this may not do what we expect for deeply nested
+		// slices of maps, but without some sort of "merge strategy",
+		// i'm not exactly sure what we expect anyway! This will
+		// completely overwrite the tgt slice with the source slice
 		if tgt == nil {
 			return true
 		}

--- a/manifestival.go
+++ b/manifestival.go
@@ -168,6 +168,7 @@ func updateChanged(src, tgt interface{}) bool {
 		for k, v := range src {
 			if updateChanged(v, tgt[k]) {
 				if _, ok := v.(map[string]interface{}); !ok || tgt[k] == nil {
+					log.V(1).Info("Update required", k, v)
 					tgt[k] = v
 				}
 				changed = true

--- a/manifestival_test.go
+++ b/manifestival_test.go
@@ -1,6 +1,7 @@
 package manifestival
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -195,6 +196,7 @@ func TestUpdateChanges(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			original := fmt.Sprintf("%+v", test.tgt)
 			actual := updateChanged(test.src, test.tgt)
 
 			if actual != test.changed {
@@ -202,7 +204,7 @@ func TestUpdateChanges(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(test.tgt, test.want) {
-				t.Errorf("Failed; got %+v; want %+v", test.tgt, test.want)
+				t.Errorf("from %+v to %s => %+v; wanted %+v", test.src, original, test.tgt, test.want)
 			}
 		})
 	}

--- a/manifestival_test.go
+++ b/manifestival_test.go
@@ -119,7 +119,7 @@ func TestUpdateChanges(t *testing.T) {
 			},
 		},
 	}, {
-		name:    "change nested slice entry",
+		name:    "add nested slice entry",
 		changed: true,
 		src: map[string]interface{}{
 			"x": map[string]interface{}{
@@ -134,6 +134,24 @@ func TestUpdateChanges(t *testing.T) {
 		want: map[string]interface{}{
 			"x": map[string]interface{}{
 				"y": []interface{}{"1", "2"},
+			},
+		},
+	}, {
+		name:    "update nested slice entry",
+		changed: true,
+		src: map[string]interface{}{
+			"x": map[string]interface{}{
+				"y": []interface{}{"1", "2", "3"},
+			},
+		},
+		tgt: map[string]interface{}{
+			"x": map[string]interface{}{
+				"y": []interface{}{"3", "6", "9"},
+			},
+		},
+		want: map[string]interface{}{
+			"x": map[string]interface{}{
+				"y": []interface{}{"1", "2", "3"},
 			},
 		},
 	}, {
@@ -153,6 +171,24 @@ func TestUpdateChanges(t *testing.T) {
 			"x": map[string]interface{}{
 				"y": []interface{}{"1", "2"},
 				"x": 2,
+			},
+		},
+	}, {
+		name:    "change map within list",
+		changed: true,
+		src: map[string]interface{}{
+			"x": map[string]interface{}{
+				"y": []interface{}{map[string]interface{}{"foo": "bar"}},
+			},
+		},
+		tgt: map[string]interface{}{
+			"x": map[string]interface{}{
+				"y": []interface{}{map[string]interface{}{"foo": "baz", "one": 1}},
+			},
+		},
+		want: map[string]interface{}{
+			"x": map[string]interface{}{
+				"y": []interface{}{map[string]interface{}{"foo": "bar"}},
 			},
 		},
 	}}

--- a/manifestival_test.go
+++ b/manifestival_test.go
@@ -1,9 +1,8 @@
-package manifestival_test
+package manifestival
 
 import (
+	"reflect"
 	"testing"
-
-	. "github.com/jcrossley3/manifestival"
 )
 
 func TestFinding(t *testing.T) {
@@ -22,5 +21,153 @@ func TestFinding(t *testing.T) {
 	}
 	if f.Find("NO", "NO", "NO") != nil {
 		t.Error("Missing resource found")
+	}
+}
+
+func TestUpdateChanges(t *testing.T) {
+	tests := []struct {
+		name    string
+		changed bool
+		src     map[string]interface{}
+		tgt     map[string]interface{}
+		want    map[string]interface{}
+	}{{
+		name:    "identical maps",
+		changed: false,
+		src: map[string]interface{}{
+			"x": map[string]interface{}{
+				"y": 1,
+			},
+		},
+		tgt: map[string]interface{}{
+			"x": map[string]interface{}{
+				"y": 1,
+			},
+		},
+		want: map[string]interface{}{
+			"x": map[string]interface{}{
+				"y": 1,
+			},
+		},
+	}, {
+		name:    "add nested map entry",
+		changed: true,
+		src: map[string]interface{}{
+			"x": map[string]interface{}{
+				"y": 1,
+			},
+		},
+		tgt: map[string]interface{}{
+			"x": map[string]interface{}{
+				"a": "foo",
+			},
+		},
+		want: map[string]interface{}{
+			"x": map[string]interface{}{
+				"y": 1,
+				"a": "foo",
+			},
+		},
+	}, {
+		name:    "change nested map entry",
+		changed: true,
+		src: map[string]interface{}{
+			"x": map[string]interface{}{
+				"y": 1,
+			},
+		},
+		tgt: map[string]interface{}{
+			"x": map[string]interface{}{
+				"y": 2,
+			},
+		},
+		want: map[string]interface{}{
+			"x": map[string]interface{}{
+				"y": 1,
+			},
+		},
+	}, {
+		name:    "change missing map entry",
+		changed: true,
+		src: map[string]interface{}{
+			"x": map[string]interface{}{
+				"y": 1,
+			},
+		},
+		tgt: map[string]interface{}{},
+		want: map[string]interface{}{
+			"x": map[string]interface{}{
+				"y": 1,
+			},
+		},
+	}, {
+		name:    "identical nested slice",
+		changed: false,
+		src: map[string]interface{}{
+			"x": map[string]interface{}{
+				"y": []interface{}{"1", "2"},
+			},
+		},
+		tgt: map[string]interface{}{
+			"x": map[string]interface{}{
+				"y": []interface{}{"1", "2"},
+			},
+		},
+		want: map[string]interface{}{
+			"x": map[string]interface{}{
+				"y": []interface{}{"1", "2"},
+			},
+		},
+	}, {
+		name:    "change nested slice entry",
+		changed: true,
+		src: map[string]interface{}{
+			"x": map[string]interface{}{
+				"y": []interface{}{"1", "2"},
+			},
+		},
+		tgt: map[string]interface{}{
+			"x": map[string]interface{}{
+				"y": []interface{}{"1"},
+			},
+		},
+		want: map[string]interface{}{
+			"x": map[string]interface{}{
+				"y": []interface{}{"1", "2"},
+			},
+		},
+	}, {
+		name:    "add missing slice entry",
+		changed: true,
+		src: map[string]interface{}{
+			"x": map[string]interface{}{
+				"y": []interface{}{"1", "2"},
+			},
+		},
+		tgt: map[string]interface{}{
+			"x": map[string]interface{}{
+				"x": 2,
+			},
+		},
+		want: map[string]interface{}{
+			"x": map[string]interface{}{
+				"y": []interface{}{"1", "2"},
+				"x": 2,
+			},
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := updateChanged(test.src, test.tgt)
+
+			if actual != test.changed {
+				t.Errorf("updateChanged() = %v, want: %v", actual, test.changed)
+			}
+
+			if !reflect.DeepEqual(test.tgt, test.want) {
+				t.Errorf("Failed; got %+v; want %+v", test.tgt, test.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
We can't overwrite some of the top-level values, so it's not as simple as calling `reflect.DeepEquals`. The question is how to handle the deeply-nested maps.