### PR TITLE
Add a reparse method to manifestival

### DIFF
--- a/manifestival.go
+++ b/manifestival.go
@@ -28,6 +28,9 @@ type Manifestival interface {
 	Get(spec *unstructured.Unstructured) (*unstructured.Unstructured, error)
 	// Transforms the resources within a Manifest
 	Transform(fns ...Transformer) error
+
+	//Reparse parses the pathname again to rebuild the Resources cache
+	Reparse(pathname string, recursive bool) error
 }
 
 type Manifest struct {
@@ -122,6 +125,16 @@ func (f *Manifest) Get(spec *unstructured.Unstructured) (*unstructured.Unstructu
 		}
 	}
 	return result, err
+}
+
+func (f *Manifest) Reparse(pathname string, recursive bool) error {
+	log.Info("Reading file", "name", pathname)
+	resources, err := Parse(pathname, recursive)
+	if err == nil {
+		log.Info("Parsed the resources: ", "path", pathname)
+		f.Resources = resources
+	}
+	return err
 }
 
 // We need to preserve the top-level target keys, specifically


### PR DESCRIPTION
This PR adds a reparse method to manifestival.

In case the scope field changes when reconciling the operator CRs, the cluster scoped resources in k8s such as clusterole, clusterrolebinding get parsed out/in based on the use-case. 

For instance, if the operator previously reconciled a Namespaced scoped CR and parsed out the cluster scope resources, and now is reconciling a cluster scoped CR, the manifest ignores the cluster scoped resources previously parsed out. 

Example code: https://github.com/openshift/kubefed-operator/blob/master/pkg/controller/kubefed/kubefed_controller.go#L259-L260

Reparse method will allow for the Resources cache to get rebuilt before a new resource reconciliation.