### PR TITLE
Immutable transforms

### DIFF
--- a/manifestival.go
+++ b/manifestival.go
@@ -37,7 +37,7 @@ type Manifestival interface {
 	// Returns a copy of the resource from the api server, nil if not found
 	Get(spec *unstructured.Unstructured) (*unstructured.Unstructured, error)
 	// Transforms the resources within a Manifest
-	Transform(fns ...Transformer) error
+	Transform(fns ...Transformer) (*Manifest, error)
 }
 
 // Manifest tracks a set of concrete resources which should be managed as a

--- a/manifestival.go
+++ b/manifestival.go
@@ -189,6 +189,11 @@ func (f *Manifest) ResourceInterface(spec *unstructured.Unstructured) (dynamic.R
 func UpdateChanged(src, tgt map[string]interface{}) bool {
 	changed := false
 	for k, v := range src {
+		// Special case for ConfigMaps
+		if k == "data" && !equality.Semantic.DeepEqual(v, tgt[k]) {
+			tgt[k], changed = v, true
+			continue
+		}
 		if v, ok := v.(map[string]interface{}); ok {
 			if tgt[k] == nil {
 				tgt[k], changed = v, true

--- a/transform.go
+++ b/transform.go
@@ -21,20 +21,21 @@ type Owner interface {
 // Transform applies an ordered set of Transformer functions to the
 // `Resources` in this Manifest.  If an error occurs, no resources are
 // transformed.
-func (f *Manifest) Transform(fns ...Transformer) error {
+func (f *Manifest) Transform(fns ...Transformer) (*Manifest, error) {
 	var results []unstructured.Unstructured
 	for i := 0; i < len(f.Resources); i++ {
 		spec := f.Resources[i].DeepCopy()
 		for _, transform := range fns {
-			err := transform(spec)
-			if err != nil {
-				return err
+			if transform != nil {
+				err := transform(spec)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 		results = append(results, *spec)
 	}
-	f.Resources = results
-	return nil
+	return &Manifest{Resources: results, client: f.client, mapper: f.mapper}, nil
 }
 
 // InjectNamespace creates a Transformer which adds a namespace to existing


### PR DESCRIPTION
The `Transform` function now returns a new manifest instead of munging its own.

Further, we now overwrite ConfigMap data instead of only mutating shared keys. This is more inline with how operators should work (fully sync a spec rather than partially) but it complicates our "need to update?" logic, since there are other resource keys (external to CM data) we do not want to update.