### PR TITLE
Bugfix: dangiling symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor/
+.idea

--- a/testdata/dangling-symlink/dangling.yaml
+++ b/testdata/dangling-symlink/dangling.yaml
@@ -1,0 +1,1 @@
+not-existing.yaml

--- a/testdata/dangling-symlink/valid.yaml
+++ b/testdata/dangling-symlink/valid.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Foo
+metadata:
+  name: acme
+---
+apiVersion: v1
+kind: Bar
+metadata:
+  name: bazinga

--- a/yaml.go
+++ b/yaml.go
@@ -79,8 +79,12 @@ func readDir(pathname string, recursive bool) ([]unstructured.Unstructured, erro
 	aggregated := []unstructured.Unstructured{}
 	for _, f := range list {
 		name := path.Join(pathname, f.Name())
-		pathDirOrFile, _ := os.Stat(name)
+		pathDirOrFile, err := os.Stat(name)
 		var els []unstructured.Unstructured
+		
+		if os.IsNotExist(err) || os.IsPermission(err) {
+			return aggregated, err
+		}
 
 		switch {
 		case pathDirOrFile.IsDir() && recursive:

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -39,6 +39,10 @@ func TestParsing(t *testing.T) {
 		path:      "testdata/missing",
 		wantError: true,
 	}, {
+		name:      "dangling symlink",
+		path:      "testdata/dangling-symlink",
+		wantError: true,
+	}, {
 		name:      "absolute path",
 		path:      filepath.Join(os.Getenv("PWD"), "testdata/tree/dir/b.yaml"),
 		recursive: true,


### PR DESCRIPTION
I've run into this issue of having *SIGSEGV* while a directory that I was reading wasn't fully checked out by `dep` (usual behavior). That caused a dangling symlink in that directory. And, that dangling symlink produced hard to debug SIGSEGV.

Proper behavior would be to return an error that states a given file isn't readable.

Here is a link to build log: https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift-knative_serverless-operator/32/pull-ci-openshift-knative-serverless-operator-master-e2e-aws/73#1:build-log.txt%3A161