### PR TITLE
Add godoc to quiet linter and assist VSCode.

### DIFF
--- a/manifestival.go
+++ b/manifestival.go
@@ -15,6 +15,9 @@ var (
 	log = logf.Log.WithName("manifestival")
 )
 
+// Manifestival allows group application of a set of Kubernetes resources
+// (typically, a set of YAML files, aka a manifest) against a Kubernetes
+// apiserver.
 type Manifestival interface {
 	// Either updates or creates all resources in the manifest
 	ApplyAll() error
@@ -30,6 +33,8 @@ type Manifestival interface {
 	Transform(fns ...Transformer) error
 }
 
+// Manifest tracks a set of concrete resources which should be managed as a
+// group using a Kubernetes client provided by `NewManifest`.
 type Manifest struct {
 	Resources []unstructured.Unstructured
 	client    client.Client
@@ -37,6 +42,10 @@ type Manifest struct {
 
 var _ Manifestival = &Manifest{}
 
+// NewManifest creates a Manifest from a comma-separated set of yaml files or
+// directories (and subdirectories if the `recursive` option is set). The
+// Manifest will be evaluated using the supplied `client` against a particular
+// Kubernetes apiserver.
 func NewManifest(pathname string, recursive bool, client client.Client) (Manifest, error) {
 	log.Info("Reading file", "name", pathname)
 	resources, err := Parse(pathname, recursive)
@@ -46,6 +55,7 @@ func NewManifest(pathname string, recursive bool, client client.Client) (Manifes
 	return Manifest{Resources: resources, client: client}, nil
 }
 
+// ApplyAll updates or creates all resources in the manifest.
 func (f *Manifest) ApplyAll() error {
 	for _, spec := range f.Resources {
 		if err := f.Apply(&spec); err != nil {
@@ -55,6 +65,8 @@ func (f *Manifest) ApplyAll() error {
 	return nil
 }
 
+// Apply updates or creates a particular resource, which does not need to be
+// part of `Resources`, and will not be tracked.
 func (f *Manifest) Apply(spec *unstructured.Unstructured) error {
 	current, err := f.Get(spec)
 	if err != nil {
@@ -78,6 +90,7 @@ func (f *Manifest) Apply(spec *unstructured.Unstructured) error {
 	return nil
 }
 
+// DeleteAll removes all tracked `Resources` in the Manifest.
 func (f *Manifest) DeleteAll(opts ...client.DeleteOptionFunc) error {
 	a := make([]unstructured.Unstructured, len(f.Resources))
 	copy(a, f.Resources)
@@ -95,6 +108,8 @@ func (f *Manifest) DeleteAll(opts ...client.DeleteOptionFunc) error {
 	return nil
 }
 
+// Delete removes the specified objects, which do not need to be registered as
+// `Resources` in the Manifest.
 func (f *Manifest) Delete(spec *unstructured.Unstructured, opts ...client.DeleteOptionFunc) error {
 	current, err := f.Get(spec)
 	if current == nil && err == nil {
@@ -110,6 +125,8 @@ func (f *Manifest) Delete(spec *unstructured.Unstructured, opts ...client.Delete
 	return nil
 }
 
+// Get collects a full resource body (or `nil`) from a partial resource
+// supplied in `spec`.
 func (f *Manifest) Get(spec *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 	key := client.ObjectKey{Namespace: spec.GetNamespace(), Name: spec.GetName()}
 	result := &unstructured.Unstructured{}
@@ -124,6 +141,8 @@ func (f *Manifest) Get(spec *unstructured.Unstructured) (*unstructured.Unstructu
 	return result, err
 }
 
+// UpdateChanged recursively merges JSON-style values in `src` into `tgt`.
+// 
 // We need to preserve the top-level target keys, specifically
 // 'metadata.resourceVersion', 'spec.clusterIP', and any existing
 // entries in a ConfigMap's 'data' field. So we only overwrite fields

--- a/transform.go
+++ b/transform.go
@@ -9,15 +9,18 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// Transform a resource from the manifest
+// Transformer transforms a resource from the manifest in place.
 type Transformer func(u *unstructured.Unstructured) error
 
+// Owner is a partial Kubernetes metadata schema.
 type Owner interface {
 	v1.Object
 	schema.ObjectKind
 }
 
-// If an error occurs, no resources are transformed
+// Transform applies an ordered set of Transformer functions to the
+// `Resources` in this Manifest.  If an error occurs, no resources are
+// transformed.
 func (f *Manifest) Transform(fns ...Transformer) error {
 	var results []unstructured.Unstructured
 	for i := 0; i < len(f.Resources); i++ {
@@ -34,7 +37,9 @@ func (f *Manifest) Transform(fns ...Transformer) error {
 	return nil
 }
 
-// We assume all resources in the manifest live in the same namespace
+// InjectNamespace creates a Transformer which adds a namespace to existing
+// resources if appropriate. We assume all resources in the manifest live in
+// the same namespace.
 func InjectNamespace(ns string) Transformer {
 	namespace := resolveEnv(ns)
 	return func(u *unstructured.Unstructured) error {
@@ -57,6 +62,8 @@ func InjectNamespace(ns string) Transformer {
 	}
 }
 
+// InjectOwner creates a Tranformer which adds an OwnerReference pointing to
+// `owner` to namespace-scoped objects.
 func InjectOwner(owner Owner) Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if !isClusterScoped(u.GetKind()) {


### PR DESCRIPTION
I was poking at https://github.com/knative/serving-operator, and noticed that there was no godoc on these methods (and that `NewManifest`'s first argument was actually a comma-separated string, rather than a single path).

Let me know if I got any of the documentation wrong.